### PR TITLE
fix: Update build.zig.zon for Zig 0.15 and fix ZEP index duplicates

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,8 +1,9 @@
 // The Zig compiler is not intended to be consumed as a package.
 // The sole purpose of this manifest file is to test the compiler.
 .{
-    .name = "zig",
+    .name = .zig,
     .version = "0.0.0",
+    .fingerprint = 0xc1ce1081501ab431,
     .dependencies = .{
         .standalone_test_cases = .{
             .path = "test/standalone",

--- a/docs/zep/README.md
+++ b/docs/zep/README.md
@@ -8,9 +8,6 @@ This directory contains all ZEPs — the mechanism by which zag evolves.
 | 0000   | ZEP Template             | —        | Process  |
 | 0001   | The Zag Language Charter | Accepted | Process  |
 | 0002   | Structured Async         | Draft    | Language |
-| 0000   | ZEP Template             | —        | Process |
-| 0001   | The Zag Language Charter | Accepted | Process |
-| 0002   | Async Structure          | Draft    | Language |
 
 ## What is a ZEP?
 


### PR DESCRIPTION
## Summary

- **build.zig.zon**: Update `.name` from string to enum literal format and add the required `.fingerprint` field for Zig 0.15.x compatibility
- **docs/zep/README.md**: Remove duplicate ZEP index entries (ZEP-0000, 0001, 0002 were listed twice)

## Test plan

- [ ] Verify `build.zig.zon` parses correctly with Zig 0.15.x
- [ ] Confirm ZEP index table renders correctly with no duplicates